### PR TITLE
feat(WhatsAppMessages): Add fake response testing and parameter_name …

### DIFF
--- a/src/WhatsAppMessages/Messages/Templates/Components/Params.php
+++ b/src/WhatsAppMessages/Messages/Templates/Components/Params.php
@@ -4,12 +4,18 @@ namespace Axolotesource\LaravelWhatsappApi\WhatsAppMessages\Messages\Templates\C
 
 class Params
 {
-    public static function text(string $text) : array
+    public static function text(string $text, ?string $parameterName = null) : array
     {
-        return [
+        $payload = [
             'type' => 'text',
             'text' => $text
         ];
+
+        if ($parameterName) {
+            $payload['parameter_name'] = $parameterName;
+        }
+
+        return $payload;
     }
 
     public static function button(string $payload): array

--- a/src/WhatsAppMessages/WhatsAppMessages.php
+++ b/src/WhatsAppMessages/WhatsAppMessages.php
@@ -23,6 +23,7 @@ use Axolotesource\LaravelWhatsappApi\WhatsAppMessages\Messages\Text\TextMessage;
  */
 class WhatsAppMessages
 {
+    protected static bool $isFake = false;
 
     public static function interactiveButtons(string $to): InteractiveButtons
     {
@@ -81,4 +82,16 @@ class WhatsAppMessages
         return new Raw($request, $to, $params);
     }
 
+    /**
+     * @throws \Exception
+     */
+    public static function fake(): void
+    {
+        self::$isFake = true;
+    }
+
+    public static function isFake(): bool
+    {
+        return self::$isFake;
+    }
 }


### PR DESCRIPTION
# Descripción
Se agrego soporte para pruebas con respuestas falsas y parameter_name en Params::text

## Tipo de cambio
- [ ] Bug fix
- [x] Feature
- [ ] Cambio disruptivo (fix o funcionalidad que causa cambio en funcionalidades existentes)

## Cómo se ha probado el cambio
Se implemento en proyecto local la librería y se probo la ejecución del mismo usando el fake y sin usarlo

## Lista de verificación
Antes de enviar tu PR, considera la siguiente lista de verificación para asegurarte de que tu PR está listo para ser revisado:
- [x] He revisado mi código
- [ ] He agregado tests que prueban mi fix o mi funcionalidad
- [ ] Los tests nuevos y existentes pasan localmente con mis cambios
- [ ] He actualizado la documentación acorde (si es necesario)

## Capturas de pantalla (si es aplicable)
### En esta imagen no estamos haciendo uso de fake()
<img width="1440" alt="Screenshot 2025-04-02 at 8 10 40 a m" src="https://github.com/user-attachments/assets/776f9292-792d-439d-80fc-cdad6bcde743" />

### En esta imagen estamos haciendo uso de fake()
<img width="1440" alt="Screenshot 2025-04-02 at 8 11 06 a m" src="https://github.com/user-attachments/assets/1e8aeac7-6304-4108-b733-a21c39a46a19" />

### En esta imagen se observa la respuesta que nos da el request
<img width="1440" alt="Screenshot 2025-04-03 at 7 13 09 a m" src="https://github.com/user-attachments/assets/3880cb8f-9cbb-41ce-b619-0fd82a8296ba" />





## Comentarios adicionales
Añade cualquier otro comentario o contexto adicional sobre el PR aquí.
